### PR TITLE
Fix parentheses-equality clang warning

### DIFF
--- a/src/seatest.c
+++ b/src/seatest.c
@@ -215,12 +215,12 @@ void seatest_assert_string_equal(char* expected, char* actual, const char* funct
           sprintf(s, "Expected <NULL> but was <NULL>");
 	  comparison = 1;
 	}
-        else if ((expected == (char *)0))
+        else if (expected == (char *)0)
 	{
 	  sprintf(s, "Expected <NULL> but was %s", actual);
 	  comparison = 0;
 	}
-        else if ((actual == (char *)0))
+        else if (actual == (char *)0)
 	{
 	  sprintf(s, "Expected %s but was <NULL>", expected);
 	  comparison = 0;


### PR DESCRIPTION
Fix for the following warnings when compiling with clang.
```
third-party/seatest/src/seatest.c:218:28: warning: equality comparison with extraneous parentheses
      [-Wparentheses-equality]
        else if ((expected == (char *)0))
                  ~~~~~~~~~^~~~~~~~~~~~
third-party/seatest/src/seatest.c:218:28: note: remove extraneous parentheses around the comparison to
      silence this warning
        else if ((expected == (char *)0))
                 ~         ^           ~
third-party/seatest/src/seatest.c:218:28: note: use '=' to turn this equality comparison into an
      assignment
        else if ((expected == (char *)0))
                           ^~
                           =
third-party/seatest/src/seatest.c:223:26: warning: equality comparison with extraneous parentheses
      [-Wparentheses-equality]
        else if ((actual == (char *)0))
                  ~~~~~~~^~~~~~~~~~~~
third-party/seatest/src/seatest.c:223:26: note: remove extraneous parentheses around the comparison to
      silence this warning
        else if ((actual == (char *)0))
                 ~       ^           ~
third-party/seatest/src/seatest.c:223:26: note: use '=' to turn this equality comparison into an
      assignment
        else if ((actual == (char *)0))
                         ^~
                         =
2 warnings generated.
```