### PR TITLE
String-related assertions now can work on constant strings

### DIFF
--- a/src/seatest.c
+++ b/src/seatest.c
@@ -210,7 +210,7 @@ void seatest_assert_double_equal( double expected, double actual, double delta, 
 	seatest_simple_test_result( result <= delta, s, function, line);	
 }
 
-void seatest_assert_string_equal(char* expected, char* actual, const char* function, unsigned int line)
+void seatest_assert_string_equal(const char* expected, const char* actual, const char* function, unsigned int line)
 {
         int comparison;
 	char s[SEATEST_PRINT_BUFFER_SIZE];
@@ -239,28 +239,28 @@ void seatest_assert_string_equal(char* expected, char* actual, const char* funct
 	seatest_simple_test_result(comparison, s, function, line);	
 }
 
-void seatest_assert_string_ends_with(char* expected, char* actual, const char* function, unsigned int line)
+void seatest_assert_string_ends_with(const char* expected, const char* actual, const char* function, unsigned int line)
 {
 	char s[SEATEST_PRINT_BUFFER_SIZE];
 	sprintf(s, "Expected %s to end with %s", actual, expected);
 	seatest_simple_test_result(strcmp(expected, actual+(strlen(actual)-strlen(expected)))==0, s, function, line);	
 }
 
-void seatest_assert_string_starts_with(char* expected, char* actual, const char* function, unsigned int line)
+void seatest_assert_string_starts_with(const char* expected, const char* actual, const char* function, unsigned int line)
 {
 	char s[SEATEST_PRINT_BUFFER_SIZE];
 	sprintf(s, "Expected %s to start with %s", actual, expected);
 	seatest_simple_test_result(strncmp(expected, actual, strlen(expected))==0, s, function, line);	
 }
 
-void seatest_assert_string_contains(char* expected, char* actual, const char* function, unsigned int line)
+void seatest_assert_string_contains(const char* expected, const char* actual, const char* function, unsigned int line)
 {
 	char s[SEATEST_PRINT_BUFFER_SIZE];
 	sprintf(s, "Expected %s to be in %s", expected, actual);
 	seatest_simple_test_result(strstr(actual, expected)!=0, s, function, line);	
 }
 
-void seatest_assert_string_doesnt_contain(char* expected, char* actual, const char* function, unsigned int line)
+void seatest_assert_string_doesnt_contain(const char* expected, const char* actual, const char* function, unsigned int line)
 {
 	char s[SEATEST_PRINT_BUFFER_SIZE];
 	sprintf(s, "Expected %s not to have %s in it", actual, expected);

--- a/src/seatest.h
+++ b/src/seatest.h
@@ -36,11 +36,11 @@ void seatest_assert_int_equal(int expected, int actual, const char* function, un
 void seatest_assert_ulong_equal(unsigned long expected, unsigned long actual, const char* function, unsigned int line);
 void seatest_assert_float_equal(float expected, float actual, float delta, const char* function, unsigned int line);
 void seatest_assert_double_equal(double expected, double actual, double delta, const char* function, unsigned int line);
-void seatest_assert_string_equal(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_ends_with(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_starts_with(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_contains(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_doesnt_contain(char* expected, char* actual, const char* function, unsigned int line);
+void seatest_assert_string_equal(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_ends_with(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_starts_with(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_contains(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_doesnt_contain(const char* expected, const char* actual, const char* function, unsigned int line);
 int  seatest_should_run( char* fixture, char* test);
 void seatest_before_run( char* fixture, char* test);
 void seatest_run_test(char* fixture, char* test);


### PR DESCRIPTION
Hi, @keithn!
Thank you for that great and tiny unit-testring library for C, we're using it to test the kernel functions of out small freeBSD-based operating system.
The problem is that you can pass non-constant `char*` pointers as `const char*` function arguments, however, it's not _correct_ pass `const char*` string literals as non-constant `char*` function arguments. Most compilers could chew it, but you gonna get a lot of warnings. I've made these arguments always constant to ensure const-correctness.
Kind regards, Roman.